### PR TITLE
Simplify channel title

### DIFF
--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -46,9 +46,9 @@ async def update_count():
 
         # update channel name
         if people_count == 1:
-            new_name = f"{people_count}-person-at-upl"
+            new_name = f"{people_count}-person-in-upl"
         else:
-            new_name = f"{people_count}-people-at-upl"
+            new_name = f"{people_count}-people-in-upl"
         await channel.edit(name=new_name)
 
         # update debug channel

--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -46,9 +46,9 @@ async def update_count():
 
         # update channel name
         if people_count == 1:
-            new_name = f"{people_count}-person-estimated-in-upl"
+            new_name = f"{people_count}-person-at-upl"
         else:
-            new_name = f"{people_count}-people-estimated-in-upl"
+            new_name = f"{people_count}-people-at-upl"
         await channel.edit(name=new_name)
 
         # update debug channel


### PR DESCRIPTION
Remove estimated because on most discord clients it cuts off the "in-upl" part. We can explain the estimation in the channel with the bot